### PR TITLE
add adjacent and neighbors

### DIFF
--- a/lib/geohash.ex
+++ b/lib/geohash.ex
@@ -118,8 +118,8 @@ defmodule Geohash do
   ```
   iex> Geohash.adjacent("abx1","n")
   "abx4"
-  ```
 
+```
   """
   def adjacent("",_direction) do
     {:error, "empty geohash"}
@@ -178,6 +178,7 @@ defmodule Geohash do
   iex> Geohash.neighbors("abx1")
   [{"n", "abx4"}, {"s", "abx0"}, {"e", "abx3"}, {"w", "abwc"}, {"ne", "abx6"},
  {"se", "abx2"}, {"nw", "abwf"}, {"sw", "abwb"}]
+
   ```
   """
   def neighbors(geohash) do

--- a/lib/geohash.ex
+++ b/lib/geohash.ex
@@ -110,6 +110,17 @@ defmodule Geohash do
     {lat, lon}
   end
 
+  @doc ~S"""
+  Calculate adjacent/2 geohash in ordinal direction ["n","s","e","w"]
+  Deals with boundary cases when adjacent is not of the same prefix.
+
+  ##Examples
+  ```
+  iex> Geohash.adjacent("abx1","n")
+  "abx4"
+  ```
+
+  """
   def adjacent("",_direction) do
     {:error, "empty geohash"}
   end
@@ -158,6 +169,17 @@ defmodule Geohash do
     q = Enum.slice(@geobase32, pos, 1)
     parent <> to_string(q)
   end
+  @doc ~S"""
+  Calculate adjacent hashes for the 8 touching neighbors/1
+
+  ## Examples
+
+  ```
+  iex> Geohash.neighbors("abx1")
+  [{"n", "abx4"}, {"s", "abx0"}, {"e", "abx3"}, {"w", "abwc"}, {"ne", "abx6"},
+ {"se", "abx2"}, {"nw", "abwf"}, {"sw", "abwb"}]
+  ```
+  """
   def neighbors(geohash) do
     ns = Enum.map( ~w(n s), fn dir -> {dir, adjacent(geohash,dir)} end)
     diag = Enum.flat_map( ~w(e w), fn dir -> Enum.map( ns, fn n2 -> {elem(n2,0) <> to_string(dir), adjacent(elem(n2,1),dir) } end) end)

--- a/test/geohash_test.exs
+++ b/test/geohash_test.exs
@@ -23,4 +23,16 @@ defmodule GeohashTest do
     assert Geohash.decode("u4pruy") == {57.648, 10.410}
     assert Geohash.decode('6gkzwgjz') == {-25.38262, -49.26561}
   end
+
+  test "Geohash.neighbors" do
+    assert Geohash.neighbors("6gkzwgjz") == [{"n", "6gkzwgmb"},
+					     {"s", "6gkzwgjy"},
+					     {"e", "6gkzwgnp"},
+					     {"w", "6gkzwgjx"},
+					     {"ne", "6gkzwgq0"},
+					     {"se", "6gkzwgnn"},
+					     {"nw", "6gkzwgm8"},
+					     {"sw", "6gkzwgjw"}]
+    assert Geohash.adjacent('ww8p1r4t8','e') == "ww8p1r4t9"
+  end
 end

--- a/test/geohash_test.exs
+++ b/test/geohash_test.exs
@@ -25,14 +25,14 @@ defmodule GeohashTest do
   end
 
   test "Geohash.neighbors" do
-    assert Geohash.neighbors("6gkzwgjz") == [{"n", "6gkzwgmb"},
-					     {"s", "6gkzwgjy"},
-					     {"e", "6gkzwgnp"},
-					     {"w", "6gkzwgjx"},
-					     {"ne", "6gkzwgq0"},
-					     {"se", "6gkzwgnn"},
-					     {"nw", "6gkzwgm8"},
-					     {"sw", "6gkzwgjw"}]
-    assert Geohash.adjacent('ww8p1r4t8','e') == "ww8p1r4t9"
+    assert Geohash.neighbors("6gkzwgjz") == %{"n" => "6gkzwgmb",
+					      "s" => "6gkzwgjy",
+					      "e" => "6gkzwgnp",
+					      "w" => "6gkzwgjx",
+					      "ne"=> "6gkzwgq0",
+					      "se"=> "6gkzwgnn",
+					      "nw"=> "6gkzwgm8",
+					      "sw"=> "6gkzwgjw"}
+    assert Geohash.adjacent("ww8p1r4t8","e") == "ww8p1r4t9"
   end
 end


### PR DESCRIPTION
function to provide geohash for an adjacent cell at the same resolution in one of the primary ordinal directions (n,s,e,w).
function provides all 8 neighbor cells, using adjacent().

methodology transcoded from https://github.com/chrisveness/latlon-geohash
