### PR TITLE
Add property based testing for adjacent functions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@
 erl_crash.dump
 *.ez
 *.beam
+
+/doc


### PR DESCRIPTION
Check that a given geohash is the neighbor of its neighbor
in the opposite direction.

e.g. `geohash == geohash |> adjacent("n") |> adjacent("s")`